### PR TITLE
Dockerfile: bump Alpine Linux version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 ##### Builder image
 ARG PERL_BUILD_VERSION=5.30-buster
-ARG ALPINE_VERSION=3.11
+ARG ALPINE_VERSION=3.19
 FROM docker.io/library/perl:${PERL_BUILD_VERSION} as builder
 
 WORKDIR /usr/local/src


### PR DESCRIPTION
Following https://stackoverflow.com/a/73374817/4715872 suggestions: Alpine signing key was rotated, so new package builds are not trusted by the old image

Closes: #622